### PR TITLE
Applications Guides - Install Sheet Logic

### DIFF
--- a/src/components/AppGuides/AppGuide/AppGuide.js
+++ b/src/components/AppGuides/AppGuide/AppGuide.js
@@ -86,8 +86,15 @@ class AppGuide extends Component {
 			application.parts.map((part, j) => {
 				if ((part.color === attr && isFloorLiner) || (part.finish === attr && !isFloorLiner)) {
 					const url = `/part/${part.oldPartNumber}`;
-					const ins = `https://www.curtmfg.com/masterlibrary/01ARIES/206003-2/installsheet/${part.oldPartNumber}_INS.pdf`;
-					const appguideCell = (<div key={j}><a href={url}>{part.oldPartNumber} - {part.short_description}</a><a href={ins} target="_blank"><Glyphicon glyph="wrench" className={s.wrench} /></a></div>);
+					const ins = `https://www.curtmfg.com/masterlibrary/01ARIES/${part.oldPartNumber}/installsheet/${part.oldPartNumber}_INS.pdf`;
+					const appguideCell = (
+						<div key={j}>
+							<a href={url}>{part.oldPartNumber} - {part.short_description}</a>
+							<a href={ins} target="_blank">
+								<Glyphicon glyph="wrench" className={s.wrench} />
+							</a>
+						</div>
+					);
 					attrToAppguide[attr].push(appguideCell);
 				}
 			});
@@ -152,7 +159,16 @@ class AppGuide extends Component {
 		this.props.guide.applications.map((app, i) => {
 			let attr = {};
 			attr = this.getAttr(app);
-			output.push(<tr key={i}><td>{app.make}</td><td>{app.model}</td><td>{app.style}</td><td>{app.min_year}</td><td>{app.max_year}</td>{attr}</tr>);
+			output.push(
+				<tr key={i}>
+					<td>{app.make}</td>
+					<td>{app.model}</td>
+					<td>{app.style}</td>
+					<td>{app.min_year}</td>
+					<td>{app.max_year}</td>
+					{attr}
+				</tr>
+			);
 		});
 		return output;
 	}

--- a/src/components/AppGuides/AppGuide/AppGuide.js
+++ b/src/components/AppGuides/AppGuide/AppGuide.js
@@ -85,14 +85,15 @@ class AppGuide extends Component {
 			attrToAppguide[attr] = [];
 			application.parts.map((part, j) => {
 				if ((part.color === attr && isFloorLiner) || (part.finish === attr && !isFloorLiner)) {
-					const url = `/part/${part.oldPartNumber}`;
-					const ins = `https://www.curtmfg.com/masterlibrary/01ARIES/${part.oldPartNumber}/installsheet/${part.oldPartNumber}_INS.pdf`;
 					const appguideCell = (
 						<div key={j}>
-							<a href={url}>{part.oldPartNumber} - {part.short_description}</a>
-							<a href={ins} target="_blank">
-								<Glyphicon glyph="wrench" className={s.wrench} />
-							</a>
+							<a href={`/part/${part.oldPartNumber}`}>{part.oldPartNumber} - {part.short_description}</a>
+							{ part.install_sheet && part.install_sheet.length > 0 ?
+								<a href={part.install_sheet} target="_blank">
+									<Glyphicon glyph="wrench" className={s.wrench} />
+								</a>
+								: null
+							}
 						</div>
 					);
 					attrToAppguide[attr].push(appguideCell);

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@ default:
 export const iapiBase = iapi;
 export const apiBase = api;
 export const envisionAPI = 'http://www.iconfigurators.com/ap-json/ap-image-AR-part-id.aspx';
-export const memcachePrefix = cachePrefix + '11152016';
+export const memcachePrefix = cachePrefix;
 export const apiKey = process.env.API_KEY !== undefined && process.env.API_KEY !== 'undefined' ? process.env.API_KEY : '9300f7bc-2ca6-11e4-8758-42010af0fd79';
 
 // Hides Where To Buy during development and review


### PR DESCRIPTION
There is a business logic case for referencing install sheets on the applications guides page that follows the following format: `https://www.curtmfg.com/masterlibrary/01ARIES/206003-2/installsheet/${part.oldPartNumber}_INS.pdf`. There are two problems with this approach:

1. The link for installation sheets is a hard-coded reference of `https://www.curtmfg.com/masterlibrary/01ARIES/206003-2/installsheet/${part.oldPartNumber}_INS.pdf` and it needs to include the part number in 2 places: `https://www.curtmfg.com/masterlibrary/01ARIES/206003-2/installsheet/${part.oldPartNumber}_INS.pdf.
2. We shouldn't have a hard-coded business logic reference to the install sheet and should use the data in the API: `http://ariesautomotive.com/api/appguide/Jeep%20Accessories/:0.json`.