### PR TITLE
Application Guides - Luverne

### DIFF
--- a/src/actions/AppGuideActionsLuverne.js
+++ b/src/actions/AppGuideActionsLuverne.js
@@ -1,0 +1,19 @@
+import AppDispatcher from '../dispatchers/AppDispatcher';
+
+class AppGuideActionsLuverne {
+	constructor() {
+		this.generateActions(
+			'set',
+			'reset',
+			'setPage',
+			'fetchAppGuides',
+			'updateAppGuides',
+			'failedAppGuides',
+			'fetchAppGuide',
+			'updateAppGuide',
+			'failedAppGuide'
+		);
+	}
+}
+
+export default AppDispatcher.createActions(AppGuideActionsLuverne);

--- a/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.js
+++ b/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.js
@@ -227,7 +227,6 @@ class AppGuideLuverne extends Component {
 				<div className={s.install}>Click the <Glyphicon glyph="wrench"/> next to a product for installation instructions.</div>
 				{this.renderDownloadLinks()}
 				<p className={s.subheading}>The application guides below will help you determine which {brand.code} parts will fit your vehicle. Each app guide is category-specific and broken down by vehicle make, model, year and style.</p>
-
 				{this.renderApplications()}
 				{this.renderPagination()}
 			</div>

--- a/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.js
+++ b/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.js
@@ -38,7 +38,7 @@ class AppGuideLuverne extends Component {
 	}
 
 	componentWillMount() {
-		const title = this.props.guide && this.props.guide.name ? this.props.guide.name : 'Application Guide';
+		const title = this.props.title;
 		this.context.onSetTitle(title);
 		this.context.onSetMeta('description', `${title} Application Guides`);
 	}
@@ -56,15 +56,10 @@ class AppGuideLuverne extends Component {
 		if (!this.props.guide.name) {
 			return null;
 		}
-		if (this.props.guide.name.toLowerCase().indexOf('floor liners') !== -1) {
-			this.props.guide.colors.map((color, i) => {
-				output.push(<th key={i}>{color}</th>);
-			});
-		} else {
-			this.props.guide.finishes.map((finish, i) => {
-				output.push(<th key={i}>{finish}</th>);
-			});
-		}
+
+		this.props.guide.finishes.map((finish, i) => {
+			output.push(<th key={i}>{finish}</th>);
+		});
 		return output;
 	}
 
@@ -72,21 +67,15 @@ class AppGuideLuverne extends Component {
 		const appguideSlice = [];
 		const attrToAppguide = {};
 		let attrToSearch = [];
-		let isFloorLiner = false;
-		if (this.props.guide.name.toLowerCase().indexOf('floor liners') !== -1) {
-			isFloorLiner = true;
-			attrToSearch = this.props.guide.colors;
-		} else {
-			attrToSearch = this.props.guide.finishes;
-		}
+		attrToSearch = this.props.guide.finishes;
 
 		attrToSearch.map((attr) => {
 			attrToAppguide[attr] = [];
 			application.parts.map((part, j) => {
-				if ((part.color === attr && isFloorLiner) || (part.finish === attr && !isFloorLiner)) {
-					const url = `/part/${part.oldPartNumber}`;
-					const ins = `https://www.curtmfg.com/masterlibrary/01ARIES/206003-2/installsheet/${part.oldPartNumber}_INS.pdf`;
-					const appguideCell = (<div key={j}><a href={url}>{part.oldPartNumber} - {part.short_description}</a><a href={ins} target="_blank"><Glyphicon glyph="wrench" className={s.wrench} /></a></div>);
+				if (part.finish === attr) {
+					const url = `/part/${part.part_number}`;
+					const ins = `https://www.curtmfg.com/masterlibrary/01LUVERNE/${part.part_number}/installsheet/${part.part_number}.pdf`;
+					const appguideCell = (<div key={j}><a href={url}>{part.part_number} - {part.short_description}</a><a href={ins} target="_blank"><Glyphicon glyph="wrench" className={s.wrench} /></a></div>);
 					attrToAppguide[attr].push(appguideCell);
 				}
 			});
@@ -118,7 +107,7 @@ class AppGuideLuverne extends Component {
 			return (
 				[
 					<li key="app"><a href={`/appguides`}>Application Guides</a></li>,
-					<li key="apps" className="active">{this.props.guide ? this.props.guide.name : null}</li>,
+					<li key="apps" className="active">{this.props.guide ? this.props.title : null}</li>,
 				]
 			);
 		}
@@ -132,7 +121,11 @@ class AppGuideLuverne extends Component {
 					<tr>
 						<th>Make</th>
 						<th>Model</th>
-						<th>Style</th>
+						<th>Body</th>
+						<th>Box Length</th>
+						<th>Cab Length</th>
+						<th>Fuel Type</th>
+						<th>Wheel Type</th>
 						<th>Start Year</th>
 						<th>End Year</th>
 						{this.getAttrs()}
@@ -151,7 +144,18 @@ class AppGuideLuverne extends Component {
 		this.props.guide.applications.map((app, i) => {
 			let attr = {};
 			attr = this.getAttr(app);
-			output.push(<tr key={i}><td>{app.make}</td><td>{app.model}</td><td>{app.style}</td><td>{app.min_year}</td><td>{app.max_year}</td>{attr}</tr>);
+			output.push(
+				<tr key={i}>
+					<td>{app.make}</td>
+					<td>{app.model}</td>
+					<td>{app.body}</td>
+					<td>{app.boxLength}</td>
+					<td>{app.cabLength}</td>
+					<td>{app.fuelType}</td>
+					<td>{app.wheelType}</td>
+					<td>{app.min_year}</td>
+					<td>{app.max_year}</td>
+				{attr}</tr>);
 		});
 		return output;
 	}
@@ -219,7 +223,7 @@ class AppGuideLuverne extends Component {
 						{this.renderBreadCrumbs()}
 					</ol>
 				</div>
-				<h1 className={s.header}>{this.props.guide.name}</h1>
+				<h1 className={s.header}>{this.props.title}</h1>
 				<div className={s.install}>Click the <Glyphicon glyph="wrench"/> next to a product for installation instructions.</div>
 				{this.renderDownloadLinks()}
 				<p className={s.subheading}>The application guides below will help you determine which {brand.code} parts will fit your vehicle. Each app guide is category-specific and broken down by vehicle make, model, year and style.</p>

--- a/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.js
+++ b/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.js
@@ -1,0 +1,235 @@
+import React, { Component, PropTypes } from 'react';
+import s from './AppGuideLuverne.scss';
+import AppGuideActions from '../../../actions/AppGuideActionsLuverne';
+import AppGuideStore from '../../../stores/AppGuideStoreLuverne';
+import withStyles from '../../../decorators/withStyles';
+import cx from 'classnames';
+import connectToStores from 'alt-utils/lib/connectToStores';
+import { Glyphicon } from 'react-bootstrap';
+import { brand } from '../../../config';
+
+const cache = '61027060';
+
+@withStyles(s)
+@connectToStores
+class AppGuideLuverne extends Component {
+
+	static propTypes = {
+		title: PropTypes.string,
+		guide: PropTypes.object,
+		page: PropTypes.number,
+	};
+
+	static contextTypes = {
+		onSetTitle: PropTypes.func.isRequired,
+		onPageNotFound: PropTypes.func.isRequired,
+		onSetMeta: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		guides: [],
+		guide: null,
+	};
+
+	constructor() {
+		super();
+		this.getAttr = this.getAttr.bind(this);
+		this.renderBreadCrumbs = this.renderBreadCrumbs.bind(this);
+	}
+
+	componentWillMount() {
+		const title = this.props.guide && this.props.guide.name ? this.props.guide.name : 'Application Guide';
+		this.context.onSetTitle(title);
+		this.context.onSetMeta('description', `${title} Application Guides`);
+	}
+
+	static getStores() {
+		return [AppGuideStore];
+	}
+
+	static getPropsFromStores() {
+		return AppGuideStore.getState();
+	}
+
+	getAttrs() {
+		const output = [];
+		if (!this.props.guide.name) {
+			return null;
+		}
+		if (this.props.guide.name.toLowerCase().indexOf('floor liners') !== -1) {
+			this.props.guide.colors.map((color, i) => {
+				output.push(<th key={i}>{color}</th>);
+			});
+		} else {
+			this.props.guide.finishes.map((finish, i) => {
+				output.push(<th key={i}>{finish}</th>);
+			});
+		}
+		return output;
+	}
+
+	getAttr(application) {
+		const appguideSlice = [];
+		const attrToAppguide = {};
+		let attrToSearch = [];
+		let isFloorLiner = false;
+		if (this.props.guide.name.toLowerCase().indexOf('floor liners') !== -1) {
+			isFloorLiner = true;
+			attrToSearch = this.props.guide.colors;
+		} else {
+			attrToSearch = this.props.guide.finishes;
+		}
+
+		attrToSearch.map((attr) => {
+			attrToAppguide[attr] = [];
+			application.parts.map((part, j) => {
+				if ((part.color === attr && isFloorLiner) || (part.finish === attr && !isFloorLiner)) {
+					const url = `/part/${part.oldPartNumber}`;
+					const ins = `https://www.curtmfg.com/masterlibrary/01ARIES/206003-2/installsheet/${part.oldPartNumber}_INS.pdf`;
+					const appguideCell = (<div key={j}><a href={url}>{part.oldPartNumber} - {part.short_description}</a><a href={ins} target="_blank"><Glyphicon glyph="wrench" className={s.wrench} /></a></div>);
+					attrToAppguide[attr].push(appguideCell);
+				}
+			});
+		});
+		attrToSearch.map((attr) => {
+			for (const i in attrToAppguide) {
+				if (i === attr) {
+					appguideSlice.push(<td key={i}>{attrToAppguide[i]}</td>);
+				}
+			}
+		});
+		return appguideSlice;
+	}
+
+	handlePagination(inc) {
+		if (this.props.page && this.props.page === 0 && inc === -1) {
+			return;
+		}
+		let currentPage = 0;
+		if (this.props.page) {
+			currentPage = this.props.page;
+		}
+		const page = currentPage + inc;
+		AppGuideActions.set(this.props.guide.name, page);
+	}
+
+	renderBreadCrumbs() {
+		if (this.props.guide) {
+			return (
+				[
+					<li key="app"><a href={`/appguides`}>Application Guides</a></li>,
+					<li key="apps" className="active">{this.props.guide ? this.props.guide.name : null}</li>,
+				]
+			);
+		}
+		return <li key="apps" className="active">Application Guides</li>;
+	}
+
+	renderApplications() {
+		return (
+			<table className={cx('table table-hover table-bordered')}>
+				<thead>
+					<tr>
+						<th>Make</th>
+						<th>Model</th>
+						<th>Style</th>
+						<th>Start Year</th>
+						<th>End Year</th>
+						{this.getAttrs()}
+					</tr>
+				</thead>
+				<tbody>{this.renderApplicationRows()}</tbody>
+			</table>
+		);
+	}
+
+	renderApplicationRows() {
+		const output = [];
+		if (!this.props.guide.applications) {
+			return null;
+		}
+		this.props.guide.applications.map((app, i) => {
+			let attr = {};
+			attr = this.getAttr(app);
+			output.push(<tr key={i}><td>{app.make}</td><td>{app.model}</td><td>{app.style}</td><td>{app.min_year}</td><td>{app.max_year}</td>{attr}</tr>);
+		});
+		return output;
+	}
+
+	renderPagination() {
+		return (
+			<div className={s.pagination}>
+				{this.props.page > 0 ? <div className={s.left} onClick={this.handlePagination.bind(this, -1)}></div> : null}
+				<div className={s.right} onClick={this.handlePagination.bind(this, 1)}></div>
+			</div>
+		);
+	}
+
+	renderDownloadLinks() {
+		const guide = this.props.guide;
+		if (guide === undefined || guide === null) {
+			return <span></span>;
+		}
+		let page = this.props.guide.name;
+		let render = false;
+		page = (page) ? page.toLowerCase() : '';
+		const links = [];
+		if (guide.appGuide === undefined || guide.appGuide === null) {
+			return <span></span>;
+		}
+		if (guide.appGuide.pdfPath) {
+			const pdfLink = `${guide.appGuide.pdfPath}?cache=${cache}`;
+			links.push(
+				<a key={1} href={pdfLink} target="_blank" analytics-on="click" analytics-event={`${page}:pdf`}>
+					<img src={'https://storage.googleapis.com/curt-icons/PDF-Icon-Aries.png'} alt="App Guide" className={cx('icon', s.appguideIcon)} />
+				</a>
+			);
+			render = true;
+		}
+		if (guide.appGuide.xlsPath) {
+			const xlsLink = `${guide.appGuide.xlsPath}?cache=${cache}`;
+			links.push(
+				<a key={2} href={xlsLink} target="_blank" analytics-on="click" analytics-event={`${page}:pdf`}>
+					<img src={'https://storage.googleapis.com/curt-icons/Excel-Icon.png'} alt="App Guide" className={cx('icon', s.appguideIcon)} />
+				</a>
+			);
+			render = true;
+		}
+
+		if (!render) {
+			return null;
+		}
+		return (
+			<div className={s.downloads}>
+				<span className="heading">Download a Copy</span>
+				{links}
+			</div>
+			);
+	}
+
+	render() {
+		if (!this.props.guide) {
+			return null;
+		}
+		return (
+			<div className={s.appguideContainer}>
+				<div className={s.breadcrumbContainer}>
+					<ol className="breadcrumb">
+						<li><a href="/">Home</a></li>
+						{this.renderBreadCrumbs()}
+					</ol>
+				</div>
+				<h1 className={s.header}>{this.props.guide.name}</h1>
+				<div className={s.install}>Click the <Glyphicon glyph="wrench"/> next to a product for installation instructions.</div>
+				{this.renderDownloadLinks()}
+				<p className={s.subheading}>The application guides below will help you determine which {brand.code} parts will fit your vehicle. Each app guide is category-specific and broken down by vehicle make, model, year and style.</p>
+
+				{this.renderApplications()}
+				{this.renderPagination()}
+			</div>
+		);
+	}
+
+}
+
+export default AppGuideLuverne;

--- a/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.scss
+++ b/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.scss
@@ -1,0 +1,65 @@
+@import '../../variables.scss';
+
+.breadcrumbContainer {
+    margin: 25px 0;
+}
+
+.wrench {
+	display: block;
+}
+
+.header {
+	display: inline;
+}
+
+.install {
+	display: inline-block;
+	margin: 15px 10px 5px;
+	font-size: 18px;
+	line-height: 30px;
+	color: #c73031;
+}
+
+.downloads {
+	display: inline;
+	float: right;
+	padding: 1em;
+	background-color: white;
+	span, a {
+		padding: .6em;
+	}
+	span {
+		font-weight: 800;
+	}
+}
+
+.appguideIcon {
+	max-height: 40px;
+}
+
+.subheading {
+	clear: both;
+}
+
+.pagination {
+	padding: 1em;
+	text-align: center;
+	.left {
+		display: inline-block;
+		width: 0;
+		height: 0;
+		margin: 2em;
+		border-top: 20px solid transparent;
+		border-right: 100px solid $new-red;
+		border-bottom: 20px solid transparent;
+	}
+	.right {
+		display: inline-block;
+		width: 0;
+		height: 0;
+		margin: 2em;
+		border-top: 20px solid transparent;
+		border-bottom: 20px solid transparent;
+		border-left: 100px solid $new-red;
+	}
+}

--- a/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.scss
+++ b/src/components/AppGuidesLuverne/AppGuideLuverne/AppGuideLuverne.scss
@@ -1,5 +1,10 @@
 @import '../../variables.scss';
 
+
+.appguideContainer{
+	margin-left:25px;
+	margin-right:25px;
+}
 .breadcrumbContainer {
     margin: 25px 0;
 }

--- a/src/components/AppGuidesLuverne/AppGuideLuverne/package.json
+++ b/src/components/AppGuidesLuverne/AppGuideLuverne/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "AppGuideLuverne",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./AppGuideLuverne.js"
+}

--- a/src/components/AppGuidesLuverne/AppGuidesLuverne.js
+++ b/src/components/AppGuidesLuverne/AppGuidesLuverne.js
@@ -2,9 +2,10 @@ import React, { Component, PropTypes } from 'react';
 import s from './AppGuidesLuverne.scss';
 import AppGuideStore from '../../stores/AppGuideStoreLuverne';
 import withStyles from '../../decorators/withStyles';
-import cx from 'classnames';
+// import cx from 'classnames';
 import connectToStores from 'alt-utils/lib/connectToStores';
 import { brand } from '../../config.js';
+import CategoryTree from '../CategoryTree';
 
 const title = 'Luverne Application Guides';
 
@@ -44,29 +45,6 @@ class AppGuidesLuverne extends Component {
 	}
 
 	renderGuides() {
-		// loop through each main category ('Running boards, nerf bars, side steps, side steps, etc')
-		const mainGuides = [];
-		if (!this.props.guideGroups) {
-			return null;
-		}
-		this.props.guideGroups.map((group, i) => {
-			mainGuides.push(<h2 key={i}>{group.title}</h2>);
-			const ags = [];
-
-			// loop through each sub category (RidgeStep, 4 oval wheel to wheel, big step 4 inch round nerf bars, etc)
-			group.appGuides.map((g, ii) => {
-				ags.push(
-					<div key={ii} className={cx(s.guideRow, 'col-xs-12', 'col-sm-6', 'col-md-6', 'col-lg-6')}>
-						<a className={cx(s.guide, 'well')} href={`/appguides/${g.collection}/0`}>
-							<img className={cx(s.guideImage)} src={g.imagePath} />
-							<div className={cx(s.guideTitle)}>{g.title}</div>
-						</a>
-					</div>
-				);
-			});
-			mainGuides.push(<div className={cx(s.subGuides, 'col-lg-12', 'col-md-12', 'col-sm-12')}>{ags}</div>);
-		});
-
 		return (
 			<div>
 				<h1>APPLICATION GUIDES</h1>
@@ -76,7 +54,7 @@ class AppGuidesLuverne extends Component {
 					category-specific and broken down by vehicle make, model,
 					year and style.
 				</p>
-				{mainGuides}
+				<CategoryTree linkOverride={'/appguides'} />
 			</div>
 		);
 	}
@@ -87,6 +65,7 @@ class AppGuidesLuverne extends Component {
 				<div className="container">
 					<ol className="breadcrumb">
 						<li><a href="/">Home</a></li>
+						<li><a className="active">Application Guides</a></li>
 					</ol>
 					{this.renderGuides()}
 				</div>

--- a/src/components/AppGuidesLuverne/AppGuidesLuverne.js
+++ b/src/components/AppGuidesLuverne/AppGuidesLuverne.js
@@ -1,0 +1,99 @@
+import React, { Component, PropTypes } from 'react';
+import s from './AppGuidesLuverne.scss';
+import AppGuideStore from '../../stores/AppGuideStoreLuverne';
+import withStyles from '../../decorators/withStyles';
+import cx from 'classnames';
+import connectToStores from 'alt-utils/lib/connectToStores';
+import { brand } from '../../config.js';
+
+const title = 'Luverne Application Guides';
+
+@withStyles(s)
+@connectToStores
+class AppGuidesLuverne extends Component {
+
+	static propTypes = {
+		guideGroups: PropTypes.array,
+		title: PropTypes.string,
+		guide: PropTypes.object,
+	};
+
+	static contextTypes = {
+		onSetTitle: PropTypes.func.isRequired,
+		onPageNotFound: PropTypes.func.isRequired,
+		onSetMeta: PropTypes.func.isRequired,
+		seo: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		guideGroups: [],
+		title,
+		guide: null,
+	};
+
+	componentWillMount() {
+		this.context.onSetTitle(title);
+	}
+
+	static getStores() {
+		return [AppGuideStore];
+	}
+
+	static getPropsFromStores() {
+		return AppGuideStore.getState();
+	}
+
+	renderGuides() {
+		// loop through each main category ('Running boards, nerf bars, side steps, side steps, etc')
+		const mainGuides = [];
+		if (!this.props.guideGroups) {
+			return null;
+		}
+		this.props.guideGroups.map((group, i) => {
+			mainGuides.push(<h2 key={i}>{group.title}</h2>);
+			const ags = [];
+
+			// loop through each sub category (RidgeStep, 4 oval wheel to wheel, big step 4 inch round nerf bars, etc)
+			group.appGuides.map((g, ii) => {
+				ags.push(
+					<div key={ii} className={cx(s.guideRow, 'col-xs-12', 'col-sm-6', 'col-md-6', 'col-lg-6')}>
+						<a className={cx(s.guide, 'well')} href={`/appguides/${g.collection}/0`}>
+							<img className={cx(s.guideImage)} src={g.imagePath} />
+							<div className={cx(s.guideTitle)}>{g.title}</div>
+						</a>
+					</div>
+				);
+			});
+			mainGuides.push(<div className={cx(s.subGuides, 'col-lg-12', 'col-md-12', 'col-sm-12')}>{ags}</div>);
+		});
+
+		return (
+			<div>
+				<h1>APPLICATION GUIDES</h1>
+				<p>
+					The application guides below will help you determine which {brand.code} parts
+					will fit your vehicle.<br /> Each app guide is
+					category-specific and broken down by vehicle make, model,
+					year and style.
+				</p>
+				{mainGuides}
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div className={s.appguidesContainer}>
+				<div className="container">
+					<ol className="breadcrumb">
+						<li><a href="/">Home</a></li>
+					</ol>
+					{this.renderGuides()}
+				</div>
+			</div>
+		);
+	}
+
+}
+
+export default AppGuidesLuverne;

--- a/src/components/AppGuidesLuverne/AppGuidesLuverne.scss
+++ b/src/components/AppGuidesLuverne/AppGuidesLuverne.scss
@@ -1,0 +1,44 @@
+@import '../variables.scss';
+
+.appguidesContainer {
+    margin: 25px 0;
+
+    a.guide {
+        display: block;
+        padding: 10px;
+        margin-bottom: 5px;
+        font-size: 1.2em;
+        text-transform: capitalize;
+        cursor: pointer;
+    }
+	.guideRow {
+		padding-left:0px;
+	}
+
+	.subGuides {
+		padding-left:0px;
+	}
+	a.guide {
+		display: block;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		margin-bottom: 5px;
+		font-size: 1.2em;
+		text-transform: capitalize;
+		cursor: pointer;
+
+		.guideImage {
+			display:block;
+			float:left;
+			max-width:80px;
+			min-width:60px;
+			height:auto;
+			margin-right:10px;
+		}
+		.guideTitle {
+			float:none;
+			min-height:81px;
+			padding-top:6%;
+		}
+	}
+}

--- a/src/components/AppGuidesLuverne/package.json
+++ b/src/components/AppGuidesLuverne/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "AppGuidesLuverne",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./AppGuidesLuverne.js"
+}

--- a/src/components/CategoryTree/CategoryItem.js
+++ b/src/components/CategoryTree/CategoryItem.js
@@ -30,10 +30,14 @@ class CategoryItem extends Component {
 		}
 
 		if (!this.props.isParent) {
+			let imgPath = '/img/partImgPlaceholder.jpg';
+			if (this.props.cat.image.Path !== '') {
+				imgPath = `${this.props.cat.image.Scheme}://${this.props.cat.image.Host}${this.props.cat.image.Path}`;
+			}
 			catItems.push(
 				<div className={s.cat} key={this.props.cat.id}>
 					<Link to={this.props.item.to} title={this.props.cat.title}>
-						<img className={cx(s.catImage)} src={`${this.props.cat.image.Scheme}://${this.props.cat.image.Host}${this.props.cat.image.Path}`} />
+						<img className={cx(s.catImage)} src={imgPath} />
 						<span className={cx(s.catTitle)}>{this.props.cat.title}</span>
 					</Link>
 				</div>

--- a/src/components/CategoryTree/CategoryItem.js
+++ b/src/components/CategoryTree/CategoryItem.js
@@ -12,6 +12,7 @@ class CategoryItem extends Component {
 		className: PropTypes.string,
 		items: PropTypes.array,
 		cat: PropTypes.object,
+		item: PropTypes.object,
 		isParent: PropTypes.bool,
 	};
 
@@ -31,7 +32,7 @@ class CategoryItem extends Component {
 		if (!this.props.isParent) {
 			catItems.push(
 				<div className={s.cat} key={this.props.cat.id}>
-					<Link to={`/category/${this.props.cat.id}/${this.props.cat.title}`} title={this.props.cat.title}>
+					<Link to={this.props.item.to} title={this.props.cat.title}>
 						<img className={cx(s.catImage)} src={`${this.props.cat.image.Scheme}://${this.props.cat.image.Host}${this.props.cat.image.Path}`} />
 						<span className={cx(s.catTitle)}>{this.props.cat.title}</span>
 					</Link>
@@ -44,6 +45,7 @@ class CategoryItem extends Component {
 				<SubItem
 					key={i}
 					cat={item.cat}
+					item={item}
 					items={item.items}
 					isParent={false}
 				/>

--- a/src/components/CategoryTree/CategoryItem.js
+++ b/src/components/CategoryTree/CategoryItem.js
@@ -22,7 +22,6 @@ class CategoryItem extends Component {
 		this.menuItems = this.categoryItems.bind(this);
 	}
 
-
 	categoryItems() {
 		const catItems = [];
 		if (!this.props.items) {
@@ -58,7 +57,6 @@ class CategoryItem extends Component {
 
 		return catItems;
 	}
-
 
 	render() {
 		return (

--- a/src/components/CategoryTree/CategoryItem.scss
+++ b/src/components/CategoryTree/CategoryItem.scss
@@ -10,6 +10,7 @@
 	.cat {
 		width:200px;
 		max-width:200px;
+		height:240px;
 		margin-right:10px;
 		float:left;
 
@@ -23,6 +24,8 @@
 		}
 		.catImage{
 			width:200px;
+			min-width:200px;
+			min-height:200px;
 		}
 	}
 }

--- a/src/components/CategoryTree/CategoryTree.js
+++ b/src/components/CategoryTree/CategoryTree.js
@@ -16,6 +16,7 @@ class CategoryTree extends Component {
 		categories: PropTypes.array,
 		params: PropTypes.object,
 		pageData: PropTypes.object,
+		linkOverride: PropTypes.string,
 	};
 
 	constructor(props) {
@@ -60,7 +61,7 @@ class CategoryTree extends Component {
 		}
 		const item = {
 			cat,
-			to: `/category/${cat.id}/${cat.title}`,
+			to: this.props.linkOverride ? `${this.props.linkOverride}/${cat.id}/${cat.title}` : `/category/${cat.id}/${cat.title}`,
 			text: cat.title,
 			children: cat.children ? cat.children.map(this.categoryToItem) : [],
 		};
@@ -89,7 +90,7 @@ class CategoryTree extends Component {
 				const elm = (
 					<div className={cx(s.categoriesContainer, 'well')} key={item.cat.id}>
 						<h2 className={s.catHeading}>{item.cat.title}</h2>
-						<CategoryItem cat={item.cat} items={subs} isParent />
+						<CategoryItem item={item} cat={item.cat} items={subs} isParent />
 					</div>
 				);
 				itemElms.push(elm);

--- a/src/components/CategoryTree/CategoryTree.js
+++ b/src/components/CategoryTree/CategoryTree.js
@@ -6,6 +6,7 @@ import CategoryStore from '../../stores/CategoryStore';
 import SiteStore from '../../stores/SiteStore';
 import connectToStores from 'alt-utils/lib/connectToStores';
 import CategoryItem from './CategoryItem';
+import { brand } from '../../config.js';
 
 @withStyles(s)
 @connectToStores
@@ -40,7 +41,11 @@ class CategoryTree extends Component {
 
 		props.categories.map((cat) => {
 			const tmp = this.categoryToItem(cat);
-			this.state.items = this.state.items.concat(tmp.items);
+			if (brand.id === 4) {
+				this.state.items = this.state.items.concat(tmp);
+			} else {
+				this.state.items = this.state.items.concat(tmp.items);
+			}
 		});
 	}
 
@@ -75,6 +80,7 @@ class CategoryTree extends Component {
 		}
 		const itemElms = [];
 		this.state.items.map((item) => {
+			console.log('item is:', item);
 			if (!item.children || !item.children.length === 0) {
 				return;
 			}
@@ -87,6 +93,7 @@ class CategoryTree extends Component {
 				subs = subs.concat(item);
 			}
 			if (subs.length > 0) {
+				console.log(subs);
 				const elm = (
 					<div className={cx(s.categoriesContainer, 'well')} key={item.cat.id}>
 						<h2 className={s.catHeading}>{item.cat.title}</h2>

--- a/src/components/CategoryTree/CategoryTree.js
+++ b/src/components/CategoryTree/CategoryTree.js
@@ -80,7 +80,6 @@ class CategoryTree extends Component {
 		}
 		const itemElms = [];
 		this.state.items.map((item) => {
-			console.log('item is:', item);
 			if (!item.children || !item.children.length === 0) {
 				return;
 			}
@@ -93,7 +92,6 @@ class CategoryTree extends Component {
 				subs = subs.concat(item);
 			}
 			if (subs.length > 0) {
-				console.log(subs);
 				const elm = (
 					<div className={cx(s.categoriesContainer, 'well')} key={item.cat.id}>
 						<h2 className={s.catHeading}>{item.cat.title}</h2>

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,6 +16,8 @@ import WhereToBuy from './components/WhereToBuy';
 import About from './components/About';
 import AppGuides from './components/AppGuides';
 import AppGuide from './components/AppGuides/AppGuide';
+import AppGuidesLuverne from './components/AppGuidesLuverne';
+import AppGuideLuverne from './components/AppGuidesLuverne/AppGuideLuverne';
 import Terms from './components/Terms';
 import Warranties from './components/Warranties';
 import LatestNews from './components/LatestNews';
@@ -29,6 +31,7 @@ import LuverneStore from './stores/LuverneStore';
 import ContactStore from './stores/ContactStore';
 import ProductStore from './stores/ProductStore';
 import AppGuideStore from './stores/AppGuideStore';
+import AppGuideStoreLuverne from './stores/AppGuideStoreLuverne';
 import GeographyStore from './stores/GeographyStore';
 import CategoryStore from './stores/CategoryStore';
 import SiteStore from './stores/SiteStore';
@@ -199,6 +202,10 @@ const router = new Router(on => {
 	});
 
 	on('/appguides', async (state) => {
+		if (brand.id === 4) {
+			await AppGuideStoreLuverne.fetchAppGuides();
+			return <AppGuidesLuverne context={state.context} />;
+		}
 		await AppGuideStore.fetchAppGuides();
 		return <AppGuides context={state.context} />;
 	});
@@ -206,6 +213,10 @@ const router = new Router(on => {
 	on('/appguides/:guide/:page', async (state) => {
 		const collection = state.params.guide;
 		const page = state.params.page;
+		if (brand.id === 4) {
+			await AppGuideStoreLuverne.fetchAppGuide(collection, page);
+			return <AppGuideLuverne context={state.context} />;
+		}
 		await AppGuideStore.fetchAppGuide(collection, page);
 		return <AppGuide context={state.context} />;
 	});
@@ -216,7 +227,7 @@ const router = new Router(on => {
 	});
 
 	on('/contact', async (state) => {
-		Promise.all([
+		await Promise.all([
 			ContactStore.fetchTypes(),
 			GeographyStore.fetchCountries(),
 		]);

--- a/src/routes.js
+++ b/src/routes.js
@@ -211,7 +211,6 @@ const router = new Router(on => {
 	});
 
 	on('/appguides/:guide/:page', async (state) => {
-		console.log('wrong route');
 		const collection = state.params.guide;
 		const page = state.params.page;
 		if (brand.id === 4) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -211,11 +211,13 @@ const router = new Router(on => {
 	});
 
 	on('/appguides/:guide/:page', async (state) => {
+		console.log('wrong route');
 		const collection = state.params.guide;
 		const page = state.params.page;
 		if (brand.id === 4) {
-			await AppGuideStoreLuverne.fetchAppGuide(collection, page);
-			return <AppGuideLuverne context={state.context} />;
+			const catID = collection;
+			await AppGuideStoreLuverne.fetchAppGuide(catID, 0);
+			return <AppGuideLuverne context={state.context} title={page} />;
 		}
 		await AppGuideStore.fetchAppGuide(collection, page);
 		return <AppGuide context={state.context} />;

--- a/src/server.js
+++ b/src/server.js
@@ -157,7 +157,6 @@ server.get('/api/luverne/appguide/:collection/:page.json', async (req, res) => {
 			}),
 		]);
 		guide = await guideResponse.json();
-		console.log(guide);
 		appGuideInfo = await appGuideInfoResponse.json();
 		guide.name = req.params.collection;
 		guide.appGuide = appGuideInfo;

--- a/src/server.js
+++ b/src/server.js
@@ -113,6 +113,60 @@ server.get('/api/envision/image.json', (req, res) => {
 	});
 });
 
+server.get('/api/luverne/appguides.json', (req, res) => {
+	memcached.get(`${memcachePrefix}api:luverne:appguides`, (err, val) => {
+		res.setHeader('Content-Type', 'application/json');
+		res.setHeader('Cache-Control', 'public, max-age=86400');
+		if (!err && val) {
+			res.json(val);
+			return;
+		}
+		fetch(`${iapiBase}/appguides/groups?key=${KEY}&brand=${brand.id}`)
+		.then((resp) => {
+			return resp.json();
+		}).then((data) => {
+			memcached.set(`${memcachePrefix}api:luverne:appguides`, data, 86400, () => {
+				res.json(data);
+			});
+		});
+	});
+});
+
+server.get('/api/luverne/appguide/:collection/:page.json', async (req, res) => {
+	memcached.get(`${memcachePrefix}api:luverne:appguide:${req.params.collection}:${req.params.page}:${brand.id}`, async (err, val) => {
+		res.setHeader('Content-Type', 'application/json');
+		res.setHeader('Cache-Control', 'public, max-age=86400');
+		if (!err && val) {
+			res.json(val);
+			return;
+		}
+		let guide = {};
+		let appGuideInfo = {};
+		const [guideResponse, appGuideInfoResponse] = await Promise.all([
+			fetch(`${apiBase}/vehicle/mongo/apps?key=${KEY}&brandID=${brand.id}&collection=${req.params.collection}&limit=1000&page=${req.params.page}`, {
+				method: 'post',
+				headers: {
+					'Accept': 'application/json',
+				},
+			}),
+			fetch(`${iapiBase}/appguides/guide?collection=${req.params.collection}&key=${KEY}&brandID=${brand.id}`, {
+				method: 'get',
+				headers: {
+					'Accept': 'application/json',
+				},
+			}),
+		]);
+		guide = await guideResponse.json();
+		appGuideInfo = await appGuideInfoResponse.json();
+		guide.name = req.params.collection;
+		guide.appGuide = appGuideInfo;
+		memcached.set(`${memcachePrefix}api:luverne:appguide:${req.params.collection}:${req.params.page}:${brand.id}`, guide, 86400, () => {
+			res.status(200).json(guide);
+			return;
+		});
+	});
+});
+
 server.get('/api/appguides.json', (req, res) => {
 	memcached.get(`${memcachePrefix}api:appguides`, (err, val) => {
 		res.setHeader('Content-Type', 'application/json');
@@ -218,7 +272,6 @@ server.get('/api/content/:slug.json', (req, res) => {
 			res.json(val);
 			return;
 		}
-
 		fetch(`${apiBase}/site/content/${slug}?siteID=${brand.id}&brandID=${brand.id}&key=${KEY}`)
 		.then((resp) => {
 			return resp.json();

--- a/src/server.js
+++ b/src/server.js
@@ -143,7 +143,7 @@ server.get('/api/luverne/appguide/:collection/:page.json', async (req, res) => {
 		let guide = {};
 		let appGuideInfo = {};
 		const [guideResponse, appGuideInfoResponse] = await Promise.all([
-			fetch(`${apiBase}/vehicle/mongo/apps?key=${KEY}&brandID=${brand.id}&collection=${req.params.collection}&limit=1000&page=${req.params.page}`, {
+			fetch(`${apiBase}/vehicle/luverne/mongo/apps?key=${KEY}&brandID=${brand.id}&catID=${req.params.collection}&limit=1000&page=${req.params.page}`, {
 				method: 'post',
 				headers: {
 					'Accept': 'application/json',
@@ -157,6 +157,7 @@ server.get('/api/luverne/appguide/:collection/:page.json', async (req, res) => {
 			}),
 		]);
 		guide = await guideResponse.json();
+		console.log(guide);
 		appGuideInfo = await appGuideInfoResponse.json();
 		guide.name = req.params.collection;
 		guide.appGuide = appGuideInfo;

--- a/src/sources/AppGuideSourceLuverne.js
+++ b/src/sources/AppGuideSourceLuverne.js
@@ -28,9 +28,9 @@ const AppGuideSourceLuverne = {
 
 	fetchAppGuide() {
 		return {
-			remote(state, collection, page) {
+			remote(state, catID, page) {
 				return new Promise((res, rej) => {
-					fetch(`/api/luverne/appguide/${collection}/:${page}.json`)
+					fetch(`/api/luverne/appguide/${catID}/:${page}.json`)
 					.then((resp) => {
 						return resp.json();
 					}).then(res).catch(rej);

--- a/src/sources/AppGuideSourceLuverne.js
+++ b/src/sources/AppGuideSourceLuverne.js
@@ -1,0 +1,56 @@
+import AppGuideActions from '../actions/AppGuideActionsLuverne';
+import fetch from '../core/fetch';
+
+const AppGuideSourceLuverne = {
+	fetchAppGuides() {
+		return {
+			remote() {
+				return new Promise((res, rej) => {
+					fetch(`/api/luverne/appguides.json`)
+					.then((resp) => {
+						return resp.json();
+					}).then(res).catch(rej);
+				});
+			},
+
+			local(st) {
+				if (st.guideGroups.length === 0) {
+					return null;
+				}
+				return st.guideGroups;
+			},
+
+			success: AppGuideActions.updateAppGuides,
+			error: AppGuideActions.failedAppGuides,
+			loading: AppGuideActions.fetchAppGuides,
+		};
+	},
+
+	fetchAppGuide() {
+		return {
+			remote(state, collection, page) {
+				return new Promise((res, rej) => {
+					fetch(`/api/luverne/appguide/${collection}/:${page}.json`)
+					.then((resp) => {
+						return resp.json();
+					}).then(res).catch(rej);
+				});
+			},
+
+			local(st) {
+				if (st.guide) {
+					return null;
+				}
+
+				return st.guide;
+			},
+
+			success: AppGuideActions.updateAppGuide,
+			error: AppGuideActions.failedAppGuide,
+			loading: AppGuideActions.fetchAppGuide,
+		};
+	},
+
+};
+
+module.exports = AppGuideSourceLuverne;

--- a/src/stores/AppGuideStoreLuverne.js
+++ b/src/stores/AppGuideStoreLuverne.js
@@ -60,14 +60,14 @@ class AppGuideStoreLuverne extends EventEmitter {
 	}
 
 	async set(args) {
-		const collection = args[0];
+		const catID = args[0];
 		let page = 0;
 		if (args.length > 1 && args[1] !== '') {
 			page = args[1];
 		}
 		const limit = 100;
 		try {
-			await fetch(`${apiBase}/vehicle/mongo/apps?key=${KEY}&brandID=3&collection=${collection}&limit=${limit}&page=${page}`, {
+			await fetch(`${apiBase}/vehicle/luverne/mongo/apps?key=${KEY}&brandID=3&catID=${catID}&limit=${limit}&page=${page}`, {
 				method: 'post',
 				headers: {
 					'Accept': 'application/json',
@@ -79,7 +79,7 @@ class AppGuideStoreLuverne extends EventEmitter {
 				if (guide.applications.length === 0) {
 					return;
 				}
-				guide.name = collection;
+				guide.name = catID;
 				this.setState({
 					guide,
 					page,

--- a/src/stores/AppGuideStoreLuverne.js
+++ b/src/stores/AppGuideStoreLuverne.js
@@ -1,0 +1,110 @@
+import AppGuideActions from '../actions/AppGuideActionsLuverne';
+import AppGuideSource from '../sources/AppGuideSourceLuverne';
+import Dispatcher from '../dispatchers/AppDispatcher';
+import events from 'events';
+import fetch from '../core/fetch';
+import { apiBase, apiKey } from '../config';
+
+const EventEmitter = events.EventEmitter;
+
+const KEY = apiKey;
+
+class AppGuideStoreLuverne extends EventEmitter {
+	constructor() {
+		super();
+		this.state = {
+			guideGroups: [],
+			guide: null,
+		};
+		this.bindListeners({
+			set: AppGuideActions.set,
+			reset: AppGuideActions.reset,
+			setPage: AppGuideActions.setPage,
+			handleUpdateAppGuides: AppGuideActions.updateAppGuides,
+			handleFailedAppGuides: AppGuideActions.failedAppGuides,
+			handleUpdateAppGuide: AppGuideActions.updateAppGuide,
+			handleFailedAppGuide: AppGuideActions.failedAppGuide,
+		});
+		this.exportAsync(AppGuideSource);
+	}
+
+	handleUpdateAppGuides(groups) {
+		const grps = groups || [];
+		if (grps.length === this.state.guideGroups.length) {
+			return;
+		}
+		this.setState({
+			guideGroups: grps,
+			guide: null,
+		});
+	}
+
+	handleFailedAppGuides(err) {
+		this.setState({
+			error: err,
+		});
+	}
+
+	handleUpdateAppGuide(guide) {
+		if (guide) {
+			this.setState({
+				guide,
+			});
+		}
+	}
+
+	handleFailedAppGuide(err) {
+		this.setState({
+			error: err,
+		});
+	}
+
+	async set(args) {
+		const collection = args[0];
+		let page = 0;
+		if (args.length > 1 && args[1] !== '') {
+			page = args[1];
+		}
+		const limit = 100;
+		try {
+			await fetch(`${apiBase}/vehicle/mongo/apps?key=${KEY}&brandID=3&collection=${collection}&limit=${limit}&page=${page}`, {
+				method: 'post',
+				headers: {
+					'Accept': 'application/json',
+				},
+			})
+			.then((resp) => {
+				return resp.json();
+			}).then((guide) => {
+				if (guide.applications.length === 0) {
+					return;
+				}
+				guide.name = collection;
+				this.setState({
+					guide,
+					page,
+				});
+			});
+		} catch (err) {
+			this.setState({
+				error: err,
+			});
+		}
+	}
+
+	reset() {
+		this.setState({
+			guide: null,
+		});
+	}
+
+	setPage(page) {
+		this.setState({
+			page,
+		});
+	}
+
+}
+
+
+export default Dispatcher.createStore(AppGuideStoreLuverne, 'AppGuideStoreLuverne');


### PR DESCRIPTION
Currently there is no application guide section for Luverne like ARIES: http://ariesautomotive.com/appguides.

@1brandeja5 has populated `Finish` as a product attribute for all Luverne items, so we can pivot out application data onto an application table. There are two adjustments that will have to be made:

1. Luverne app data is in year/make/model/body/fuel/cab/box format.
2. There is no Godzilla (flat collection) data structure, so we'll have to pull the application data directly off the product collection and aggregate it into groups using the category hierarchy.