### PR TITLE
Fix #235 Async Re-fetch in Header

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -52,12 +52,6 @@ const context = {
 function render(state) {
 	Router.dispatch(state, (newState, component) => {
 		ReactDOM.render(component, appContainer, () => {
-			// Restore the scroll position if it was saved into the state
-			if (state.scrollY !== undefined) {
-				window.scrollTo(state.scrollX, state.scrollY);
-			} else {
-				window.scrollTo(0, 0);
-			}
 			// Remove the pre-rendered CSS because it's no longer used
 			// after the React app is launched
 			if (cssContainer) {


### PR DESCRIPTION
Scroll position was being restored in 2 places. appContainer commponent was
reading from state that was not being saved anywhere, so dead code was removed