### PR TITLE
Fix #250 Dealer Locator not working

### DIFF
--- a/src/components/WhereToBuy/Locations/Locations.js
+++ b/src/components/WhereToBuy/Locations/Locations.js
@@ -53,6 +53,9 @@ class Locations extends Component {
 	}
 
 	shuffle(array) {
+		if (!(array && array.length)) {
+			return [];
+		}
 		for (let i = array.length - 1; i > 0; i--) {
 			const j = Math.floor(Math.random() * (i + 1));
 			const temp = array[i];


### PR DESCRIPTION
Shuffle logic did not take in to account cases where a tier (Gold, Silver, Platinum)
was missing from the dealers.